### PR TITLE
Fix markdown for hyperlinks to reading material.

### DIFF
--- a/reading_calls/r_markdown.md
+++ b/reading_calls/r_markdown.md
@@ -10,6 +10,6 @@ There are several benefits to this:
 
 Now, I'd like you to read a little more detail about the system in R For Data Science. Please read the following: 
 
-- [https://r4ds.had.co.nz/communicate-intro.html](Chapter 26) in the digital version of _R For Data Science_ and [https://r4ds.had.co.nz/r-markdown.html](Chapter 27) in the same. 
+- [Chapter 26](https://r4ds.had.co.nz/communicate-intro.html) in the digital version of _R For Data Science_ and [Chapter 27](https://r4ds.had.co.nz/r-markdown.html) in the same. 
 - In Chapter 27, read sections 1-6, skipping section 7. 
 - If you're reading in the physical copy, these are the chapters about "Communicating" and "R Markdown"


### PR DESCRIPTION
Screenshot of the markdown change preview: 
![image](https://user-images.githubusercontent.com/6217186/113965019-7a496c00-97e1-11eb-8ac8-462620b6b99c.png)

Currently the course's hyperlinks are displayed incorrectly and do not direct to the proper webpages:
![image](https://user-images.githubusercontent.com/6217186/113965099-9ea54880-97e1-11eb-9a1b-51f6c8139a9b.png)
![image](https://user-images.githubusercontent.com/6217186/113965165-baa8ea00-97e1-11eb-97ce-713742fa5b18.png)


This should fix the hyperlinks and display correctly in the course page.

Thanks!

