### PR TITLE
Fix broken Rstudio IDE cheatsheet link

### DIFF
--- a/reading_calls/keyboard_shortcuts.md
+++ b/reading_calls/keyboard_shortcuts.md
@@ -2,5 +2,5 @@
 
 The Rstudio team maintains a really great series of one-page resources for many of the major projects in R and Rstudio. They are located on this [cheatsheets](https://rstudio.com/resources/cheatsheets/) website.
 
-- Particularily relevant at this point is the cheatsheet that describes how to interact with the [Rstudio IDE](https://github.com/rstudio/cheatsheets/raw/master/rstudio-ide.pdf). 
+- Particularily relevant at this point is the cheatsheet that describes how to interact with the [Rstudio IDE](https://github.com/rstudio/cheatsheets/blob/main/rstudio-ide.pdf). 
 - We have also saved a frozen copy of this cheatsheet in the course repo (./resources/cheatsheet-rstudio_ide.pdf).


### PR DESCRIPTION
The original link was broken showing 404. 