### PR TITLE
Update link in keyboard_shortcuts.md

### DIFF
--- a/reading_calls/keyboard_shortcuts.md
+++ b/reading_calls/keyboard_shortcuts.md
@@ -2,5 +2,5 @@
 
 The Rstudio team maintains a really great series of one-page resources for many of the major projects in R and Rstudio. They are located on this [cheatsheets](https://rstudio.com/resources/cheatsheets/) website.
 
-- Particularily relevant at this point is the cheatsheet that describes how to interact with the [Rstudio IDE](https://github.com/rstudio/cheatsheets/raw/master/rstudio-ide.pdf). 
+- Particularily relevant at this point is the cheatsheet that describes how to interact with the [Rstudio IDE](https://github.com/rstudio/cheatsheets/raw/main/rstudio-ide.pdf). 
 - We have also saved a frozen copy of this cheatsheet in the course repo (./resources/cheatsheet-rstudio_ide.pdf).


### PR DESCRIPTION
The existing link to rstudio-ide.pdf was broken. The rstudio/cheatsheets repository now uses a branch named `main` instead of `master`.