### PR TITLE
Delete reading_calls/exploratory_data_analysis.md

### DIFF
--- a/reading_calls/exploratory_data_analysis.md
+++ b/reading_calls/exploratory_data_analysis.md
@@ -1,3 +1,0 @@
-# A blank page
-
-Right now, there's no work that I would like you to do at this page. Keep on [Truckin'](https://www.youtube.com/watch?v=pafY6sZt0FE).  


### PR DESCRIPTION
There's a "call to reading" for exploratory data analysis in module  3.4.3, so this this file (corresponding to module 3.2.6) can probably be deleted.

> ⚠️ ** Is there a table of contents this needs to be deleted from?
> I'm unsure the process of how this gets from the repo to the LMS'ified version on bcourses; I was expecting to need to delete some reference to that places this file as module 3.4.3 but couldn't find one.